### PR TITLE
Fix "dist-tag add" copy text

### DIFF
--- a/problems/11-dist-tag/problem.en.txt
+++ b/problems/11-dist-tag/problem.en.txt
@@ -13,10 +13,10 @@ these distribution tags with the `dist-tag` function.
 
 `npm dist-tag add <pkg>@<version> [<tag>]` will add a new tag.
 To find out the name of your current package/version type `npm ls`.
-The first line of the output will be the package and version; e.g. user@1.0.1.
+The first line of the output will be the package and version; e.g. pkg@1.0.1.
 To add a tag type in the name of the tag.
 
-  npm dist-tag add user@1.0.1 beta
+  npm dist-tag add pkg@1.0.1 beta
 
 Run `npm help dist-tag` to learn more about it.
 

--- a/problems/11-dist-tag/problem.es.txt
+++ b/problems/11-dist-tag/problem.es.txt
@@ -20,7 +20,7 @@ por ejemplo, `mipaquete@1.0.1`.
 
 Para añadir la etiqueta, esribe el nombre que quieres usar:
 
-  npm dist-tag add user@1.0.1 beta
+  npm dist-tag add pkg@1.0.1 beta
 
 Haz `npm help dist-tag` para aprender más.
 

--- a/problems/11-dist-tag/problem.ja.txt
+++ b/problems/11-dist-tag/problem.ja.txt
@@ -15,10 +15,10 @@ npm に公開されたパッケージは、いずれも `dist-tags` (配布タ�
 
 `npm dist-tag add <pkg> @ <version> [<tag>]` で新しいタグを追加することができます。
 現在のパッケージ・バージョンの名前を調べるには `npm ls` を入力してください。
-出力の最初の行はパッケージとバージョンです(例えば user@1.0.1)。
+出力の最初の行はパッケージとバージョンです(例えば pkg@1.0.1)。
 タグ名を追加するのは、このようになります。
 
-  npm dist-tag add user@1.0.1 beta
+  npm dist-tag add pkg@1.0.1 beta
 
 `npm help dist-tag` を実行すれば、もっと詳しく学べます。
 


### PR DESCRIPTION
It was suggesting user@1.0.1 which is missleading.

Documentation (`npm help dist-tag`) tells us:

```
npm dist-tag add <pkg>@<version> [<tag>]
```